### PR TITLE
test: ignore teardown error

### DIFF
--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -21,6 +21,9 @@ const pollingConfig = config => {
   config.server.watch ??= {}
   config.server.watch.usePolling = true
   config.server.watch.interval = 100
+
+  // FIXME: needs to change otherwise docker tests will fail with "EACCES: permission denied, mkdir"
+  config.cacheDir = '.cache/vite'
   return config
 }
 export default pollingConfig($1)

--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -21,9 +21,6 @@ const pollingConfig = config => {
   config.server.watch ??= {}
   config.server.watch.usePolling = true
   config.server.watch.interval = 100
-
-  // FIXME: needs to change otherwise docker tests will fail with "EACCES: permission denied, mkdir"
-  config.cacheDir = '.cache/vite'
   return config
 }
 export default pollingConfig($1)

--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -86,7 +86,7 @@ async function globalSetup(_config: FullConfig) {
   try {
     await Promise.all([setupExamples(), setupFixtures()])
   } catch (e) {
-    console.error('globalSetup error', e)
+    console.error('globalSetup error')
     throw e
   }
 }

--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -83,7 +83,12 @@ async function globalSetup(_config: FullConfig) {
     console.warn('Warning: Using local node_modules. It only works with linux.')
   }
 
-  await Promise.all([setupExamples(), setupFixtures()])
+  try {
+    await Promise.all([setupExamples(), setupFixtures()])
+  } catch (e) {
+    console.error('globalSetup error', e)
+    throw e
+  }
 }
 
 export default globalSetup

--- a/tests/globalTeardown.ts
+++ b/tests/globalTeardown.ts
@@ -8,8 +8,7 @@ async function globalTeardown(_config: FullConfig) {
       await fs.rm(exampleTempDir, { force: true, recursive: true })
       await fs.rm(fixtureTempDir, { force: true, recursive: true })
     } catch (e) {
-      console.error('globalTeardown error', e)
-      throw e
+      console.warn('globalTeardown error', e)
     }
   }
 }

--- a/tests/globalTeardown.ts
+++ b/tests/globalTeardown.ts
@@ -4,8 +4,13 @@ import { isDebug, exampleTempDir, fixtureTempDir } from './utils/index.js'
 
 async function globalTeardown(_config: FullConfig) {
   if (!isDebug) {
-    await fs.rm(exampleTempDir, { force: true, recursive: true })
-    await fs.rm(fixtureTempDir, { force: true, recursive: true })
+    try {
+      await fs.rm(exampleTempDir, { force: true, recursive: true })
+      await fs.rm(fixtureTempDir, { force: true, recursive: true })
+    } catch (e) {
+      console.error('globalTeardown error', e)
+      throw e
+    }
   }
 }
 


### PR DESCRIPTION
When the process wasn't killed correctly, `fs.rm` fails with EACCESS.
To reduce flaky fails, just ignore those errors.
