### PR TITLE
docs(proxy): add hints for `https` (nginx)

### DIFF
--- a/examples/with-proxy/docker/nginx/vite.conf
+++ b/examples/with-proxy/docker/nginx/vite.conf
@@ -3,13 +3,9 @@ map $http_upgrade $connection_upgrade {
     ''      close;
 }
 
-upstream vite_origin {
-    server localhost:5173;
-}
-
 server {
     listen 3000;
-    ## if you are using SSL:
+    ## if you want to use HTTPS:
     # listen 443 ssl;
     # ssl_certificate      server.crt;
     # ssl_certificate_key  server.key;
@@ -21,7 +17,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $host;
 
-        proxy_pass  http://vite_origin;
+        proxy_pass  http://vite:5173;
 
         # proxy ws
         proxy_set_header Upgrade $http_upgrade;

--- a/examples/with-proxy/docker/nginx/vite.conf
+++ b/examples/with-proxy/docker/nginx/vite.conf
@@ -3,15 +3,25 @@ map $http_upgrade $connection_upgrade {
     ''      close;
 }
 
+upstream vite_origin {
+    server localhost:5173;
+}
+
 server {
     listen 3000;
+    ## if you are using SSL:
+    # listen 443 ssl;
+    # ssl_certificate      server.crt;
+    # ssl_certificate_key  server.key;
+    # ssl_session_cache    shared:SSL:1m;
+    # ssl_session_timeout  5m;
 
     location / {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $host;
 
-        proxy_pass  http://vite:5173;
+        proxy_pass  http://vite_origin;
 
         # proxy ws
         proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
In cases that HTTPS is forced, we can use the same config, only port & ssl changed.

Browsers will request `wss://vite_origin(:443)/` if http host is `localhost(:80)`.