### PR TITLE
test: call docker compose down once

### DIFF
--- a/tests/utils/index.ts
+++ b/tests/utils/index.ts
@@ -232,6 +232,7 @@ export const runDockerCompose = async (
 
   const stdout = collectOutput(process.stdout)
   const stderr = collectOutput(process.stderr)
+  let isDownCalled = false
 
   return {
     process,
@@ -247,6 +248,9 @@ export const runDockerCompose = async (
       recordedLogs.push('------')
     },
     down: async () => {
+      if (isDownCalled) return
+
+      isDownCalled = true
       const success = process.kill('SIGINT')
       if (!success) {
         console.warn('failed to sigint docker compose')


### PR DESCRIPTION
If it throws at this line,
https://github.com/sapphi-red/vite-setup-catalogue/blob/a5d1633578fde72ededb6bc791f72c9285e41ced/tests/examples-cases/with-proxy-no-websocket.ts#L76
`finishVite1` is already called, but it will be called here as well.
https://github.com/sapphi-red/vite-setup-catalogue/blob/a5d1633578fde72ededb6bc791f72c9285e41ced/tests/examples-cases/with-proxy-no-websocket.ts#L84
