### PR TITLE
fix: set `tty: true` and `stdin_open: true` for vite containers

### DIFF
--- a/examples/with-proxy-no-websocket/compose.dev.yaml
+++ b/examples/with-proxy-no-websocket/compose.dev.yaml
@@ -19,6 +19,8 @@ services:
       - node_modules:/app/node_modules
     working_dir: /app
     command: bash -c "npm i && npm run dev"
+    tty: true # to make the logs use colors
+    stdin_open: true # to keep the dev server running
 
 volumes:
   caddy_data:

--- a/examples/with-proxy/compose.dev-apache.yaml
+++ b/examples/with-proxy/compose.dev-apache.yaml
@@ -16,6 +16,8 @@ services:
       - node_modules:/app/node_modules
     working_dir: /app
     command: bash -c "npm i && npm run dev"
+    tty: true # to make the logs use colors
+    stdin_open: true # to keep the dev server running
 
 volumes:
   node_modules:

--- a/examples/with-proxy/compose.dev-nginx.yaml
+++ b/examples/with-proxy/compose.dev-nginx.yaml
@@ -15,6 +15,8 @@ services:
       - node_modules:/app/node_modules
     working_dir: /app
     command: bash -c "npm i && npm run dev"
+    tty: true # to make the logs use colors
+    stdin_open: true # to keep the dev server running
 
 volumes:
   node_modules:

--- a/examples/with-proxy/compose.dev.yaml
+++ b/examples/with-proxy/compose.dev.yaml
@@ -17,6 +17,8 @@ services:
       - node_modules:/app/node_modules
     working_dir: /app
     command: bash -c "npm i && npm run dev"
+    tty: true # to make the logs use colors
+    stdin_open: true # to keep the dev server running
 
 volumes:
   caddy_data:

--- a/tests/examples-overrides/with-proxy-no-websocket/compose.node-modules-outside-container.yaml
+++ b/tests/examples-overrides/with-proxy-no-websocket/compose.node-modules-outside-container.yaml
@@ -6,3 +6,5 @@ services:
       - .:/repo-root/examples/with-proxy-no-websocket
     working_dir: /repo-root/examples/with-proxy-no-websocket
     command: npm run dev
+    tty: true # to make the logs use colors
+    stdin_open: true # to keep the dev server running

--- a/tests/examples-overrides/with-proxy/compose.node-modules-outside-container.yaml
+++ b/tests/examples-overrides/with-proxy/compose.node-modules-outside-container.yaml
@@ -6,3 +6,5 @@ services:
       - .:/repo-root/examples/with-proxy
     working_dir: /repo-root/examples/with-proxy
     command: npm run dev
+    tty: true # to make the logs use colors
+    stdin_open: true # to keep the dev server running


### PR DESCRIPTION
Maybe this is needed because of https://github.com/vitejs/vite/pull/20837